### PR TITLE
Prevent double callback calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "k-fastify-gateway",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "k-fastify-gateway",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "A Node.js API Gateway that just works!",
   "main": "index.js",
   "scripts": {

--- a/test/on-finished.test.js
+++ b/test/on-finished.test.js
@@ -1,0 +1,53 @@
+/* global describe, it, beforeEach */
+
+const onFinished = require('../src/plugins/on-finished')
+const expect = require('chai').expect
+
+describe('on-finished', () => {
+  let data
+  let res
+
+  beforeEach((done) => {
+    data = ''
+    res = {
+      statusCode: 200,
+      getHeaders: () => {
+        return {}
+      },
+      write: function (content) {
+        if (content) data += content
+      },
+      end: function (content, encoding) {
+        if (content) data += content
+      }
+    }
+
+    done()
+  })
+
+  it('should accumulate string content', function (done) {
+    onFinished(res, (payload) => {
+      expect(payload.data).to.equal('hello world')
+      expect(data).to.equal('hello world')
+      done()
+    })
+
+    res.write(undefined)
+    res.write('h')
+    res.write(Buffer.from('ello'))
+    res.write(' ')
+    res.end('world')
+  })
+
+  it('should accumulate non-string content', function (done) {
+    onFinished(res, (payload) => {
+      expect(payload.data).to.equal(true)
+      done()
+    })
+
+    res.end(true)
+
+    // checks recursiveness is prevented
+    res.end(true)
+  })
+})


### PR DESCRIPTION
- Prevent double callback calls if res.end is called twice.
- Increase code coverage.